### PR TITLE
fastclockin

### DIFF
--- a/fastclk.h
+++ b/fastclk.h
@@ -1,6 +1,6 @@
 #ifndef _FASTCLK_H
 #define _FASTCLK_H
-// Written by Mutaz Hussain 2017
+// Written by Mutaz Hussain Nov 2017 bluecard82[@]gmail[.]com
 // tjtag  modfication to be more fast
 // xilinx type cable
 
@@ -39,7 +39,4 @@ unsigned int clockin_fast (unsigned char lowclk,unsigned char highclk,unsigned c
 // without heavy math instruction could
 // cost big time with megabytes flashed
 
-//in ReadWritedata func there is loop
-// for (int i=0;i <30; i++)
-// data  |= clockin_fast(clk_low[0][(indata&imask[i]?1:0)],clk_high[0][(indata&imask[i]?1:0)],i);
-//clockin_fast(clk_low[1][(indata&imask[i]?1:0)],clk_high[1][(indata&imask[i]?1:0)],i)
+#endif

--- a/fastclk.h
+++ b/fastclk.h
@@ -27,7 +27,7 @@ unsigned char wclk_high[2][2] =
 {0x96,0x9E}
 };
 
-unsigned int imsk[32] =
+unsigned int imask[32] =
  {0x00000001, 0x00000002, 0x00000004, 0x00000008, 
  0x00000010, 0x00000020, 0x00000040, 0x00000080, 
  0x00000100, 0x00000200, 0x00000400, 0x00000800,
@@ -36,9 +36,6 @@ unsigned int imsk[32] =
  0x00100000, 0x00200000, 0x00400000, 0x00800000, 
 0x01000000, 0x02000000, 0x04000000, 0x08000000
 0x10000000, 0x20000000, 0x40000000,0x80000000};
-unsigned int clockin_fast (unsigned char lowclk,unsigned char highclk,unsigned char imask);
-// new way to send direct values to Lpt
-// without heavy math instruction could
-// cost big time with megabytes flashed
+
 
 #endif

--- a/fastclk.h
+++ b/fastclk.h
@@ -1,0 +1,45 @@
+#ifndef _FASTCLK_H
+#define _FASTCLK_H
+// Written by Mutaz Hussain 2017
+// tjtag  modfication to be more fast
+// xilinx type cable
+
+unsigned char clk_low[2][2] =
+{{0x10,0x11},
+{0x14,0x15}
+};
+
+unsigned char clk_high[2][2] =
+{ {0x12,0x13},
+{0x16,0x17}
+};
+
+// wiggler type cable
+unsigned char wclk_low[2][2] =
+ { {0x90,0x98},
+{0x92,0x9B}
+};
+
+unsigned char wclk_high[2][2] =
+{ {0x94,0x9C},
+{0x96,0x9E}
+};
+
+unsigned int imsk[32] =
+ {0x00000001, 0x00000002, 0x00000004, 0x00000008, 
+ 0x00000010, 0x00000020, 0x00000040, 0x00000080, 
+ 0x00000100, 0x00000200, 0x00000400, 0x00000800,
+0x00001000, 0x00002000, 0x00004000, 0x00008000, 
+0x00010000, 0x00020000, 0x00040000, 0x00080000,
+ 0x00100000, 0x00200000, 0x00400000, 0x00800000, 
+0x01000000, 0x02000000, 0x04000000, 0x08000000
+0x10000000, 0x20000000, 0x40000000,0x80000000};
+unsigned int clockin_fast (unsigned char lowclk,unsigned char highclk,unsigned char imask);
+// new way to send direct values to Lpt
+// without heavy math instruction could
+// cost big time with megabytes flashed
+
+//in ReadWritedata func there is loop
+// for (int i=0;i <30; i++)
+// data  |= clockin_fast(clk_low[0][(indata&imask[i]?1:0)],clk_high[0][(indata&imask[i]?1:0)],i);
+//clockin_fast(clk_low[1][(indata&imask[i]?1:0)],clk_high[1][(indata&imask[i]?1:0)],i)

--- a/fastclk.h
+++ b/fastclk.h
@@ -2,6 +2,7 @@
 #define _FASTCLK_H
 // Written by Mutaz Hussain Nov 2017 bluecard82[@]gmail[.]com
 // tjtag  modfication to be more fast
+// using as clk_low[tms][tdi] (when tclk 0) clk_high[tms][tdi] (when tclk 1) 
 // xilinx type cable
 
 unsigned char clk_low[2][2] =
@@ -14,6 +15,7 @@ unsigned char clk_high[2][2] =
 {0x16,0x17}
 };
 
+// all time wtrst is 1, using wclk_low[wtms][wtdi] (when wtckl 0) wclk_high[wtms][wtdi] (when wtclk 1) 
 // wiggler type cable
 unsigned char wclk_low[2][2] =
  { {0x90,0x98},

--- a/tjtag.c
+++ b/tjtag.c
@@ -36,7 +36,7 @@
 
 #include "tjtag.h"
 #include "spi.h"
-
+#include "fastclk.h"
 #define TRUE  1
 #define FALSE 0
 
@@ -504,9 +504,10 @@ static unsigned char clockin(int tms, int tdi)
     tms = tms ? 1 : 0;
     tdi = tdi ? 1 : 0;
 // yoon's remark we set wtrst_n to be d4 so we are going to drive it low
-    if (wiggler) data = (1 << WTDO) | (0 << WTCK) | (tms << WTMS) | (tdi << WTDI)| (1 << WTRST_N);
-    else        data = (1 << TDO) | (0 << TCK) | (tms << TMS) | (tdi << TDI);
-    cable_wait();
+        if (wiggler) data = wclk_low[tms][tdi];
+  //  else        data = (1 << TDO) | (0 << TCK) | (tms << TMS) | (tdi << TDI);
+  else  data = clk_low[tms][tdi];
+	cable_wait();
 
 
 #ifdef WINDOWS_VERSION   // ---- Compiler Specific Code ----
@@ -515,8 +516,8 @@ static unsigned char clockin(int tms, int tdi)
 
     ioctl(pfd, PPWDATA, &data);
 #endif
-    if (wiggler) data = (1 << WTDO) | (1 << WTCK) | (tms << WTMS) | (tdi << WTDI) | (1 << WTRST_N);
-    else        data = (1 << TDO) | (1 << TCK) | (tms << TMS) | (tdi << TDI);
+    if (wiggler) data = wclk_high[tms][tdi];
+    else        data = clck_high[tms][tdi];
     cable_wait();
 
 

--- a/tjtag.c
+++ b/tjtag.c
@@ -568,7 +568,7 @@ void set_instr(int instr)
     clockin(0, 0);  // enter shift-ir (dummy)
     for (i=0; i < instruction_length; i++)
     {
-        clockin(i==(instruction_length - 1), (instr>>i)&1);
+        clockin(i==(instruction_length - 1), (instr&imask[i])?1:0);
     }
     clockin(1, 0);  // enter update-ir
     clockin(0, 0);  // enter runtest-idle
@@ -591,7 +591,7 @@ static unsigned int ReadWriteData(unsigned int in_data)
     clockin(0, 0);  // enter shift-dr
     for (i = 0 ; i < 32 ; i++)
     {
-        out_bit  = clockin((i == 31), ((in_data >> i) & 1));
+        out_bit  = clockin((i == 31), ((in_data & imask[i])?1:0));
         out_data = out_data | (out_bit << i);
     }
     clockin(1,0);   // enter update-dr


### PR DESCRIPTION
creat fastclk.h containing:
 - direct values that will send to LPT , because calculating this value one every time to send only 1 bits
make huge time that not useful in Mbyts range data flashing.
- add array imask for 32bit to accelerate process of masking.
change tjtag.c by implanting those arrays inside ReadWriteData function and set_instruct functions.